### PR TITLE
ci(fix): Grant write on security-events API to CodeQL Analysis

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -83,6 +83,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: read
+      security-events: write
 
     timeout-minutes: 10
 


### PR DESCRIPTION
The workflow failed[^workflow] with HTTP 403 on `PUT /repos/renovatebot/renovate-approve-bot-bitbucket-cloud/code-scanning/analysis/status`.

Documentation:

- https://github.com/github/codeql-action#usage
- https://docs.github.com/en/actions/learn-github-actions/workflow-syntax-for-github-actions#permissions
- https://docs.github.com/en/actions/security-guides/automatic-token-authentication#permissions-for-the-github_token
- https://docs.github.com/en/rest/reference/permissions-required-for-github-apps#permission-on-security-events

[^workflow]: https://github.com/renovatebot/renovate-approve-bot-bitbucket-cloud/runs/4327379068