### PR TITLE
fix: Fixed invalid results on the automerge check

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const got = require('got');
 const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, RENOVATE_BOT_USER } =
   process.env;
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
-const AUTO_MERGE_MESSAGE = "**Automerge**: Enabled."
+const AUTO_MERGE_MESSAGE = '**Automerge**: Enabled.';
 
 const DEFAULT_OPTIONS = {
   prefixUrl: 'https://api.bitbucket.org',
@@ -28,7 +28,10 @@ const log = bunyan.createLogger({
 
 function isAutomerging(pr) {
   try {
-    return pr.description.includes(AUTO_MERGE_MESSAGE) && !pr.description.includes(MANUAL_MERGE_MESSAGE);
+    return (
+      pr.description.includes(AUTO_MERGE_MESSAGE) &&
+      !pr.description.includes(MANUAL_MERGE_MESSAGE)
+    );
   } catch (error) {
     log.error(error);
     return false;

--- a/index.js
+++ b/index.js
@@ -4,6 +4,7 @@ const got = require('got');
 const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, RENOVATE_BOT_USER } =
   process.env;
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
+const AUTO_MERGE_MESSAGE = "🚦 **Automerge**: Enabled."
 
 const DEFAULT_OPTIONS = {
   prefixUrl: 'https://api.bitbucket.org',
@@ -27,7 +28,7 @@ const log = bunyan.createLogger({
 
 function isAutomerging(pr) {
   try {
-    return !pr.description.includes(MANUAL_MERGE_MESSAGE);
+    return pr.description.includes(AUTO_MERGE_MESSAGE) && !pr.description.includes(MANUAL_MERGE_MESSAGE);
   } catch (error) {
     log.error(error);
     return false;

--- a/index.js
+++ b/index.js
@@ -4,7 +4,7 @@ const got = require('got');
 const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, RENOVATE_BOT_USER } =
   process.env;
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
-const AUTO_MERGE_MESSAGE = "🚦 **Automerge**: Enabled."
+const AUTO_MERGE_MESSAGE = "**Automerge**: Enabled."
 
 const DEFAULT_OPTIONS = {
   prefixUrl: 'https://api.bitbucket.org',


### PR DESCRIPTION
## Changes:

Added an extra check that checks if the repository description includes the automerge tag.

## Context:

In it's current state, the auto approver also approves PR's that are created from the same user, but without the automerge tag. (eg. our automatic configure renovate PR).

## Documentation (please check one with an [x])

- [ ] I have updated the documentation, or
- [x] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository
