### PR TITLE
fix!: use workspace API to get pull requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ On each run, the bot will:
 5. Set the environment variables:
    - `BITBUCKET_USERNAME`: Bitbucket username associated with the account used for renovate-approve-bot
    - `BITBUCKET_PASSWORD`: Bitbucket App password created in step 2
+   - `BITBUCKET_WORKSPACE`: Bitbucket workspace in which PR's will be searched for and approved
    - `RENOVATE_BOT_USER`: Bitbucket username of your Renovate Bot
 6. Run the bot (on a schedule similarly to Renovate Bot, e.g. as a [Cron](https://en.wikipedia.org/wiki/Cron) job):
 
@@ -32,6 +33,7 @@ On each run, the bot will:
      docker run --rm \
        --env BITBUCKET_USERNAME \
        --env BITBUCKET_PASSWORD \
+       --env BITBUCKET_WORKSPACE \
        --env RENOVATE_BOT_USER \
        ghcr.io/renovatebot/renovate-approve-bot-bitbucket-cloud:latest
      ```
@@ -47,7 +49,7 @@ On each run, the bot will:
 
 Example to run renovate-approve-bot in a custom Bitbucket Pipeline on a schedule:
 
-1. Add `BITBUCKET_USERNAME` and `BITBUCKET_PASSWORD` to your [repository variables](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Repository-variables)
+1. Add `BITBUCKET_USERNAME` and `BITBUCKET_PASSWORD` and `BITBUCKET_WORKSPACE` to your [repository variables](https://support.atlassian.com/bitbucket-cloud/docs/variables-and-secrets/#Repository-variables)
 2. Create a custom pipeline in your `bitbucket-pipelines.yml` file
 
    ```yaml

--- a/index.js
+++ b/index.js
@@ -1,8 +1,12 @@
 const bunyan = require('bunyan');
 const got = require('got');
 
-const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, BITBUCKET_WORKSPACE, RENOVATE_BOT_USER } =
-  process.env;
+const {
+  BITBUCKET_USERNAME,
+  BITBUCKET_PASSWORD,
+  BITBUCKET_WORKSPACE,
+  RENOVATE_BOT_USER,
+} = process.env;
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
 const AUTO_MERGE_MESSAGE = '**Automerge**: Enabled.';
 
@@ -74,7 +78,12 @@ function approvePullRequest(prHref) {
 }
 
 async function main() {
-  if (!BITBUCKET_USERNAME || !BITBUCKET_PASSWORD || !BITBUCKET_WORKSPACE || !RENOVATE_BOT_USER) {
+  if (
+    !BITBUCKET_USERNAME ||
+    !BITBUCKET_PASSWORD ||
+    !BITBUCKET_WORKSPACE ||
+    !RENOVATE_BOT_USER
+  ) {
     log.fatal(
       'At least one of BITBUCKET_USERNAME, BITBUCKET_PASSWORD, BITBUCKET_WORKSPACE, RENOVATE_BOT_USER environement variables is not set.'
     );

--- a/index.js
+++ b/index.js
@@ -1,7 +1,7 @@
 const bunyan = require('bunyan');
 const got = require('got');
 
-const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, RENOVATE_BOT_USER } =
+const { BITBUCKET_USERNAME, BITBUCKET_PASSWORD, BITBUCKET_WORKSPACE, RENOVATE_BOT_USER } =
   process.env;
 const MANUAL_MERGE_MESSAGE = 'merge this manually';
 const AUTO_MERGE_MESSAGE = '**Automerge**: Enabled.';
@@ -39,7 +39,7 @@ function isAutomerging(pr) {
 }
 
 function getPullRequests() {
-  const prEndpoint = `/2.0/pullrequests/${RENOVATE_BOT_USER}`;
+  const prEndpoint = `/2.0/workspaces/${BITBUCKET_WORKSPACE}/pullrequests/${RENOVATE_BOT_USER}`;
   log.info('Requesting %s%s...', DEFAULT_OPTIONS.prefixUrl, prEndpoint);
 
   return got.paginate('', {
@@ -74,9 +74,9 @@ function approvePullRequest(prHref) {
 }
 
 async function main() {
-  if (!BITBUCKET_USERNAME || !BITBUCKET_PASSWORD || !RENOVATE_BOT_USER) {
+  if (!BITBUCKET_USERNAME || !BITBUCKET_PASSWORD || !BITBUCKET_WORKSPACE || !RENOVATE_BOT_USER) {
     log.fatal(
-      'At least one of BITBUCKET_USERNAME, BITBUCKET_PASSWORD, RENOVATE_BOT_USER environement variables is not set.'
+      'At least one of BITBUCKET_USERNAME, BITBUCKET_PASSWORD, BITBUCKET_WORKSPACE, RENOVATE_BOT_USER environement variables is not set.'
     );
     process.exit(1);
   }

--- a/index.spec.js
+++ b/index.spec.js
@@ -2,6 +2,7 @@ const nock = require('nock');
 
 const BITBUCKET_USERNAME = 'renovate-approve-bot';
 const BITBUCKET_PASSWORD = 'r3novate-@pprove-b0t';
+const BITBUCKET_WORKSPACE = 'myworkspace';
 const RENOVATE_BOT_USER = 'renovate-bot';
 
 process.env = Object.assign(process.env, {
@@ -55,7 +56,7 @@ describe('isAutomerging', () => {
 });
 
 describe('getPullRequests', () => {
-  const pullRequestsEndpoint = `/2.0/pullrequests/${RENOVATE_BOT_USER}`;
+  const pullRequestsEndpoint = `/2.0/pullrequests/${BITBUCKET_WORKSPACE}/pullrequests/${RENOVATE_BOT_USER}`;
 
   it('gets pull-requests in a single page', async () => {
     nock(API_BASE_URL)

--- a/index.spec.js
+++ b/index.spec.js
@@ -57,7 +57,7 @@ describe('isAutomerging', () => {
 });
 
 describe('getPullRequests', () => {
-  const pullRequestsEndpoint = `/2.0/pullrequests/${BITBUCKET_WORKSPACE}/pullrequests/${RENOVATE_BOT_USER}`;
+  const pullRequestsEndpoint = `/2.0/workspaces/${BITBUCKET_WORKSPACE}/pullrequests/${RENOVATE_BOT_USER}`;
 
   it('gets pull-requests in a single page', async () => {
     nock(API_BASE_URL)

--- a/index.spec.js
+++ b/index.spec.js
@@ -8,6 +8,7 @@ const RENOVATE_BOT_USER = 'renovate-bot';
 process.env = Object.assign(process.env, {
   BITBUCKET_USERNAME,
   BITBUCKET_PASSWORD,
+  BITBUCKET_WORKSPACE,
   RENOVATE_BOT_USER,
 });
 


### PR DESCRIPTION
<!-- Make sure the `Allow edits and access to secrets by maintainers` checkbox is checked on this pull request. -->

## Changes:

Change code to align with Bitbucket deprecated api. https://community.atlassian.com/forums/Bitbucket-articles/Reminder-List-pull-requests-for-a-user-API-removal/ba-p/293

## Context:
- closes #943
<!-- Describe why you're making these changes if it's not already explained in a corresponding issue. -->
<!-- If you're closing an existing issue with this pull request, use the keyword Closes #issue_number -->

## Documentation (please check one with an [x])

- [x ] I have updated the documentation, or
- [ ] No documentation update is required

## How I've tested my work (please tick one)

I have verified these changes via:

- [ ] Code inspection only, or
- [ ] Newly added/modified unit tests, or
- [ x] No unit tests but ran on a real repository, or
- [ ] Both unit tests + ran on a real repository

<!-- Do you have any suggestions about this PR template? Edit it here: https://github.com/renovatebot/renovate-approve-bot-bitbucket-cloud/edit/main/.github/pull_request_template.md -->

<!-- Please do not force push to your PR's branch after you have created your PR, as doing so forces us to review the whole PR again. This makes it harder for us to review your work because we don't know what has changed. -->
<!-- PRs will always be squashed by us when we merge your work. Commit as many times as you need in this branch. -->
